### PR TITLE
Signal optionality of PIV Middleware conformance

### DIFF
--- a/_Appendix/accreditation.md
+++ b/_Appendix/accreditation.md
@@ -68,7 +68,7 @@ and its associated technical specifications is needed in order to meet the secur
 goals of [[HSPD-12]](references.md#ref-HSPD-12). To facilitate this, NIST has established the NIST Personal Identity Verification
 Program (NPIVP). Under this program NIST has developed test procedures in SP 800-85A, *PIV Card
 Application and Middleware Interface Test Guidelines (SP 800-73 compliance)*, and an associated toolkit
-for conformance testing of PIV Card Applications and PIV Middleware [[SP 800-85A]](references.md#ref-SP-800-85A). Note, NPIVP conformace testing also covers PIV Middleware, however, conformance testing may be discontinued at a future time as computer/device platforms increasingly support built-in native smart cards support
+for conformance testing of PIV Card Applications and PIV Middleware [[SP 800-85A]](references.md#ref-SP-800-85A). Note, NPIVP conformance testing also covers PIV Middleware, however, conformance testing may be discontinued at a future time as computer platforms increasingly provide built-in support for smart cards.
 
 Commercial products under these two categories are tested by the set of accredited test laboratories, accredited under
 the National Voluntary Laboratory Accreditation Program (NVLAP) program, using the NIST supplied
@@ -98,4 +98,3 @@ the card products tested under the PIV Validation Program, physical access contr
 approved under this process are placed on the FIPS 201 Approved Products List to promote procurement
 of conformant products by implementing agencies. The details of the program are available at
 [https://www.idmanagement.gov/](https://www.idmanagement.gov/).
-


### PR DESCRIPTION
I've also changed A.2 as well -- as SP 800-79 is now not only about PIV Card Issuer Controls but also about Derived PIV Credential Issuer Controls.