### PR TITLE
Add "PIV Account" Definition

### DIFF
--- a/_Appendix/glossary.md
+++ b/_Appendix/glossary.md
@@ -248,7 +248,7 @@ Personal Identification Number (PIN)
 his or her identity.
 
 Personal Identity Verification (PIV) Account
-: The logical repository for credentialing information for a given PIV cardholder.  This is typically stored within the Issuer’s Identity Management System, and includes PIV enrollment data, cardholder identity attributes, and information regarding authenticators bound the cardholder’s identity (e.g., PIV card and derived PIV credentials).
+: The logical record containing credentialing information for a given PIV cardholder.  This is typically stored within the issuer’s identity management system, and includes PIV enrollment data, cardholder identity attributes, and information regarding authenticators bound to the cardholder’s identity (e.g., PIV card and derived PIV credentials).
 
 Personal Identity Verification (PIV) Card
 : A physical artifact (e.g., identity card, "smart" card) issued


### PR DESCRIPTION
First draft of a new definition for PIV account.  Note that IDMS was already defined in FIPS 201.  It's rough, so comments/edits are more than welcome.