### PR TITLE
ISO/IEC 24727 section deletion

### DIFF
--- a/_FIPS201/frontend.md
+++ b/_FIPS201/frontend.md
@@ -755,7 +755,7 @@ computing systems, the reader-to-host system interface is not specified in this 
 
 ### 4.4.3 Reader Interoperability (Removed) {#s-4-4-3}
 
-The content of this section has been removed as the PIV middleware specified in [[SP 800-73]](../_Appendix/references.md#ref-SP-800-73) adaquately covers reader resilience and flexibility for different PIV systems.
+The content of this section has been removed as the PIV middleware specified in [[SP 800-73]](../_Appendix/references.md#ref-SP-800-73) adaquately covers reader interoperability, resilience, and flexibility for different PIV systems.
 
 ### 4.4.4 Card Activation Device Requirements {#s-4-4-4}
 


### PR DESCRIPTION
addresses  issue 162  (https://github.com/usnistgov/PIV-issues/issues/162).  Note: I left in the text about achieving interoperability via federation.  If this section is the wrong place for the federation text, we should find a home for it (rather than delete).