### PR TITLE
added SHALL NOT statement to use of removed items

### DIFF
--- a/_FIPS201/introduction.md
+++ b/_FIPS201/introduction.md
@@ -113,7 +113,8 @@ agency decides to support the OCC-AUTH authentication mechanism.
 When a feature is to be discontinued or is no longer needed, it is deprecated. In general, a feature that is
 currently in use by relying systems would only be deprecated if there is a compelling
 reason to do so (e.g., security). Deprecated features MAY continue to be used, but SHOULD be phased out in future systems
-since the feature will likely be removed in the next revision of the Standard. Removed features SHALL NOT be used. For example, the CHUID authentication mechanism ([Section 6.2.5](authentication.md#s-6-2-5)) has been removed from this version of the Standard
+since the feature will likely be removed in the next revision of the Standard. Removed features SHALL NOT be used. For example, the CHUID
+authentication mechanism ([Section 6.2.5](authentication.md#s-6-2-5)) has been removed from this version of the Standard
 and relying systems SHALL NOT use this authentication
 mechanism.[^CHUID] The VIS authentication mechanism ([Section 6.2.6](authentication.md#s-6-2-6)) has been deprecated as a stand-alone
 authentication mechanism, but it could still be used in conjunction with other authentication mechanisms.


### PR DESCRIPTION
takes care of issue [134](https://github.com/usnistgov/PIV-issues/issues/134)
also corrected verb -> from 'were' to 'is' in line 364