### PR TITLE
Capitalize all acronyms before acronym-ized

### DIFF
--- a/_Appendix/accreditation.md
+++ b/_Appendix/accreditation.md
@@ -44,7 +44,7 @@ personnel of the PCI and DPCI organization and the review of documents such as t
 assessment phase, the appropriate assessment methods stipulated in the methodology for each PCI/DPCI and control
 are carried out and the individual results recorded. The accreditation phase involves aggregating the
 results of assessment, arriving at an accreditation decision, and issuing the appropriate notification – the
-authorization to operate (ATO) or the denial of authorization to operate (DATO), that is consistent with
+Authorization To Operate (ATO) or the Denial of Authorization To Operate (DATO), that is consistent with
 the accreditation decision.
 
 

--- a/_Appendix/references.md
+++ b/_Appendix/references.md
@@ -130,7 +130,7 @@ Revocation List (CRL) Profile*, IETF, October 2015. Available at <https://www.ie
 
 [[RISK-MGMT-FACILITIES]](#ref-RISK-MGMT-FACILITIES){:name="ref-RISK-MGMT-FACILITIES"} *The Risk Management Process for Federal Facilities: An Interagency Security Committee Standard*, Interagency Security Committee, November, 2016. Available at <https://www.cisa.gov/sites/default/files/publications/isc-risk-management-process-2016-508.pdf>.
 
-[[SAML-AC]](#ref-SAML-AC){:name="ref-SAML-AC"} Authentication Context for the OASISSecurity Assertion Markup Language(SAML) V2.0, OASIS, March 2005.
+[[SAML-AC]](#ref-SAML-AC){:name="ref-SAML-AC"} Authentication Context for the OASIS Security Assertion Markup Language (SAML) V2.0, OASIS, March 2005.
 Available at <https://docs.oasis-open.org/security/saml/v2.0/saml-authn-context-2.0-os.pdf>.
 
 [[SP 800-37]](#ref-SP-800-37){:name="ref-SP-800-37"} NIST Special Publication 800-37 Revision 2, *Risk Management Framework for Information Systems and Organizations: A System Life Cycle Approach for Security and Privacy*, NIST,

--- a/_FIPS201/authentication.md
+++ b/_FIPS201/authentication.md
@@ -55,8 +55,8 @@ authentication mechanisms that may be applied to a particular situation.
 ### 6.2.1 Authentication Using Off-Card Biometric One-to-One Comparison {#s-6-2-1}
 
 The PIV Card Application hosts the signed fingerprint biometric templates and, optionally, the signed electronic iris images.
-Either mode of biometric data record can be read from the card following cardholder-to-card (CTC) authentication using a PIN
-supplied by the cardholder. This biometric data record is designed to support a cardholder-to-external
+Either mode of biometric data record can be read from the card following Cardholder-To-Card (CTC) authentication using a PIN
+supplied by the cardholder. This biometric data record is designed to support a Cardholder-To-External
 system (CTE) authentication mechanism through an off-card biometric one-to-one comparison scheme. The following subsections
 define two authentication schemes that make use of biometric data records.[^bioreaders]
 
@@ -105,7 +105,7 @@ are the same as in [Section 6.2.1.1](#s-6-2-1-1).
 
 The PIV Card Application MAY host an optional on-card fingerprint one-to-one comparison algorithm. In this case,
 on-card fingerprint one-to-one comparison data is stored on the card, which cannot be read, but could be used for
-biometric verification. A fingerprint biometric template is supplied to the card to perform cardholder-to-card (CTC)
+biometric verification. A fingerprint biometric template is supplied to the card to perform Cardholder-To-Card (CTC)
 authentication and the card responds with an positive or negative biometric verification decision.
 The response includes information that allows the reader to authenticate the card. The
 cardholder PIN is not required for this operation. The PIV Card SHALL include a mechanism to block this
@@ -123,7 +123,7 @@ Some of the characteristics of OCC authentication are as follows:
 ### 6.2.3 Authentication Using PIV Asymmetric Cryptography {#s-6-2-3}
 
 The PIV Card contains two mandatory asymmetric authentication private keys and corresponding
-certificates to support cardholder-to-external system (CTE) authentication, as described in [Section 4](frontend.md#s-4). The
+certificates to support Cardholder-To-External system (CTE) authentication, as described in [Section 4](frontend.md#s-4). The
 following subsections describe how to perform authentication using the authentication keys.
 
 #### 6.2.3.1 Authentication with the PIV Authentication Certificate Credential (PKI-AUTH) {#s-6-2-3-1}

--- a/_FIPS201/federation.md
+++ b/_FIPS201/federation.md
@@ -8,7 +8,7 @@ permalink: /federation/
 
 # 7. Federation Considerations for PIV {#s-7}
 
-Federation protocols allow a trusted identity provider (IdP) to assert a subscriber's identity to a relying party (RP) across a network in a secure and verifiable fashion. The process and requirements for federation systems are discussed in depth in [[SP 800-63C]](#ref-sp-800-63C). 
+Federation protocols allow a trusted identity provider (IdP) to assert a subscriber's identity to a Relying Party (RP) across a network in a secure and verifiable fashion. The process and requirements for federation systems are discussed in depth in [[SP 800-63C]](#ref-sp-800-63C).
 
 ## 7.1 Connecting PIV to Federation {#s-7-1}
 

--- a/_FIPS201/frontend.md
+++ b/_FIPS201/frontend.md
@@ -102,7 +102,7 @@ The following list describes the physical requirements for the PIV Card.
     alter or interfere with printed information, including the photograph; or
     damage or interfere with machine-readable technology, such as the embedded antenna.
 - The card material SHALL withstand the effects of temperatures required by the application of a polyester
-    laminate on one or both sides of the card by commercial off-the-shelf (COTS) equipment. The
+    laminate on one or both sides of the card by Commercial Off-The-Shelf (COTS) equipment. The
     thickness added due to a laminate layer SHALL NOT interfere with the smart card reader operation. The
     card material SHALL allow production of a flat card in accordance with [[ISO7810]](../_Appendix/references.md#ref-ISO7810) after lamination of
     one or both sides of the card.
@@ -553,7 +553,7 @@ The PIV Card SHALL store a corresponding X.509 certificate to support validation
 The X.509 certificate SHALL include the FASC-N in the Subject Alternative Name (SAN) extension using the
 pivFASC-N attribute to support physical access procedures. The X.509 certificate SHALL also include
 the UUID value from the GUID data element of the CHUID in the Subject Alternative Name extension.
-The UUID SHALL be encoded as a uniform resource name (URN), as specified in Section 3 of
+The UUID SHALL be encoded as a Uniform Resource Name (URN), as specified in Section 3 of
 [[RFC4122]](../_Appendix/references.md#ref-RFC4122). The expiration date of the certificate SHALL be no later than the expiration date of the PIV
 Card. The PIV authentication certificate MAY include a PIV background investigation indicator (previously known as the NACI indicator) extension (see Appendix B.2). 
 This non-critical extension indicates the status

--- a/_FIPS201/introduction.md
+++ b/_FIPS201/introduction.md
@@ -104,7 +104,7 @@ PIV Card would need to be changed to accept the new PIV AID.
 
 New features are optional or mandatory features that are added to the Standard. New features do not
 interfere with backward compatibility because they are not part of the existing relying systems. For
-example, the addition of an optional biometric on-card comparison (OCC) authentication mechanism is a
+example, the addition of an optional biometric On-Card Comparison (OCC) authentication mechanism is a
 new feature that does not affect the features in current systems. The systems will need to be updated if an
 agency decides to support the OCC-AUTH authentication mechanism.
 

--- a/_FIPS201/requirements.md
+++ b/_FIPS201/requirements.md
@@ -169,7 +169,7 @@ The biometric data records in the PIV enrollment records SHALL be valid for at m
 effects and thereby maintain operational readiness of a cardholder's PIV Card, agencies MAY require
 biometric enrollment more frequently than 12 years.
 
-PIV enrollment records contain personally identifiable information (PII). PII SHALL be protected
+PIV enrollment records contain Personally Identifiable Information (PII). PII SHALL be protected
 in a manner that protects the individual's privacy and maintains the integrity of the records
 both in transit and at rest. 
 
@@ -389,7 +389,7 @@ If the expiration date of the new PIV Card is later than the expiration date of 
 about the cardholder is being changed, the card issuer SHALL ensure that an adjudicative entity has authorized
 the issuance of the new PIV Card. The issuer SHALL ensure that the adjudicative entity has verified that there is a PIV eligibility determination in the system of record.[^record] 
 
-[^record]: The identity management system (IDMS) SHOULD reflect the PIV eligibility of each PIV cardholder and the subsequent re-enrollment in Continuous Vetting Program, as appropriate.
+[^record]: The Identity Management System (IDMS) SHOULD reflect the PIV eligibility of each PIV cardholder and the subsequent re-enrollment in Continuous Vetting Program, as appropriate.
 
 The issuer SHALL perform a biometric verification of the applicant to the chain-of-trust to reconnect to the chain-of-trust. The one-to-one
 comparison requires either fingerprint(s) or, if unavailable, other optional biometric data records
@@ -406,7 +406,7 @@ The old PIV Card SHALL be revoked when the new PIV Card is issued. The revocatio
 + Any databases maintained by the PIV Card issuer that contain FASC-N or UUID values from the old
     PIV Card must be updated to reflect the change in status.
 + If the old PIV Card cannot be collected and destroyed, or if the old PIV Card has been compromised
-    or damaged, then the certification authority (CA) SHALL be informed and the certificates corresponding
+    or damaged, then the Certification Authority (CA) SHALL be informed and the certificates corresponding
     to the PIV authentication key ([Section 4.2.2.1](frontend.md#s-4-2-2-1)) and asymmetric card authentication key ([Section 4.2.2.2](frontend.md#s-4-2-2-2)) on the old PIV Card SHALL be
     revoked. If present, the certificates corresponding to the digital signature key ([Section 4.2.2.1](frontend.md#s-4-2-2-4)) and the key
     management key ([Section 4.2.2.5](frontend.md#s-4-2-2-5)) SHALL also be revoked.
@@ -494,7 +494,7 @@ remotely via a general computing platform:
     * the cardholder initiates a PIN reset with the issuer operator;
     * the operator authenticates the owner of the PIV Card through an independent
         procedure; and
-    * the cardholder's biometric characteristics elicit a positive biometric verification decision when compared to the stored biometric data records on the PIV Card through an on-card one-to-one comparison (OCC).
+    * the cardholder's biometric characteristics elicit a positive biometric verification decision when compared to the stored biometric data records on the PIV Card through a one-to-one On-Card Comparison (OCC).
 
 The remote PIN reset operation SHALL satisfy the requirements for remote post-issuance updates
 specified in [Section 2.9.2](requirements.md#s-2-9-2).

--- a/_FIPS201/system.md
+++ b/_FIPS201/system.md
@@ -31,7 +31,7 @@ An operational PIV system can be logically divided into the following three majo
     resource.
 - **PIV Issuance and Management Subsystem**—the components responsible for identity
     proofing and registration, card and key issuance and management, and the various repositories and
-    services (e.g., public key infrastructure (PKI) directory, certificate status servers) required as part of
+    services (e.g., Public Key Infrastructure (PKI) directory, certificate status servers) required as part of
     the verification infrastructure. This subsystem also manages the binding and termination of derived PIV credentials as described in [Section 2.10](requirements.md#s-2-10).
 - **PIV Relying Subsystem**—the physical and logical access control systems, the protected resources,
     and the authorization data.
@@ -56,7 +56,7 @@ is not meant to preclude FIPS 201 requirements on systems outside these boundari
 
 The PIV Card will be issued to the applicant when all identity proofing, registration, and issuance
 processes have been completed. Derived PIV credentials might also be issued after post-enrollment binding is complete. The PIV Card takes the physical form of the [[ISO7816]](../_Appendix/references.md#ref-ISO7816) ID-1 card type (i.e., traditional payment card), with one or more
-embedded integrated circuit chips (ICC) that provide memory capacity and computational capability. The
+embedded Integrated Circuit Chips (ICC) that provide memory capacity and computational capability. The
 PIV Card is the primary component of the PIV system. The holder uses the PIV Card for authentication
 to various physical and logical resources. Derived PIV credentials increasingly play an important role as additional authenticators, especially in environments where use of the PIV Card is not easily supported. These AAL2 and/or AAL3 authenticators are not embedded in the PIV Card, but rather are stand-alone or integrated in a variety of devices/platforms. 
 
@@ -120,7 +120,7 @@ program) to which the cardholder wants to gain access.
 
 The relying system depends on an authorization data component that defines the privileges (authorizations)
 possessed by entities requesting to access a particular logical or physical resource. An example of this is
-an access control list (ACL) associated with a file on a computer system.
+an Access Control List (ACL) associated with a file on a computer system.
 
 The physical and logical access control system grants or denies access to a particular resource and
 includes an identification and authentication (I&A) component as well as an authorization component.


### PR DESCRIPTION
Chose the style of ensuring the terms before the acronym are always capitalized, except when *sic* in a cited reference's title.

Integration should close usnistgov/piv-issues#173.