### PR TITLE
a -> the to accommodate multiple DPCs. Fixes usnistgov/PIV-issues#174

### DIFF
--- a/_FIPS201/requirements.md
+++ b/_FIPS201/requirements.md
@@ -566,8 +566,8 @@ Special Publication 800-157, *Guidelines for Derived Personal Identity Verificat
 
 Derived PIV credentials SHALL be invalidated in any of the following circumstances:
 
-* Upon request of the PIV cardholder as a result of loss, failure, compromise, or intent to discontinue use of the derived PIV credential.
-* At the determination of the PIV account issuer upon reported loss or suspected compromise of the derived PIV credential.
+* Upon request of the PIV cardholder as a result of loss, failure, compromise, or intent to discontinue use of a derived PIV credential.
+* At the determination of the PIV account issuer upon reported loss or suspected compromise of a derived PIV credential.
 * At the determination of the PIV account issuer upon observation of possible fraudulent activity.
 * When a cardholder is no longer eligible to have a PIV Card as specified in [Section 2.9.4](requirements.md#s-2-9-4). In this situation, all derived PIV credentials associated with the PIV account SHALL be invalidated.
 


### PR DESCRIPTION
There are still a couple of occurrences of "the derived" but these refer to a specific DPC that is being invalidated, so these remain.