### PR TITLE
Ensure expanded acronym always comes first.

### DIFF
--- a/_FIPS201/authentication.md
+++ b/_FIPS201/authentication.md
@@ -29,7 +29,7 @@ protocol, as described in [Section 7](#s-7).
 
 This Standard defines multiple levels of assurance for logical and physical access. Each assurance level establishes a degree of confidence that the presenter of
 the PIV Card is the person referred to by the PIV credential. The entity performing the authentication further establishes confidence that the person referred to by the PIV credential is a specific identified person through the rigor of the identity proofing process conducted prior to issuance of the PIV Card and the security of the PIV Card issuance and maintenance processes specified in [Section 2](requirements.md#s-2) of this Standard. The PIV identity proofing, registration, issuance, and maintenance processes meet or exceed the
-requirements for Identity Assurance Level 3 (IAL3) [[SP 800-63A]](../_Appendix/references.md#ref-SP-800-63A).
+requirements for IAL3 [[SP 800-63A]](../_Appendix/references.md#ref-SP-800-63A).
 
 The PIV Card contains a number of logical credentials that are used by the authentication mechanisms specified in [Section 6.2](#s-6-2). Varying assurance levels that the holder of the PIV Card is
 the owner of the card can be achieved, depending on the PIV authentication mechanism used. The assurance levels for physical and logical access are specified in [Section 6.3.1](#s-6-3-1) and [Section 6.3.2](#s-6-3-2) respectively.
@@ -42,7 +42,7 @@ specified in [Section 6.2](#s-6-2) SHALL be applied to achieve that assurance le
 
 ### 6.1.1 Relationship to Federal Identity Policy (Removed) {#s-6-1-1}
 
-The content of this section has been removed as OMB M-04-04 has been rescinded by OMB [[M-19-17]](../_Appendix/references.md#ref-OMB1917), which recognizes the identity assurance levels defined in NIST [[SP 800-63]](../_Appendix/references.md#ref-SP-800-63) as the framework for managing digital identity risks within the federal government. A mapping between PIV authentication mechanisms and SP 800-63 assurance levels can be found in [Section 6.3.2](#s-6-3-2).
+The content of this section has been removed as OMB M-04-04 has been rescinded by OMB [[M-19-17]](../_Appendix/references.md#ref-OMB1917), which recognizes the IALs defined in NIST [[SP 800-63]](../_Appendix/references.md#ref-SP-800-63) as the framework for managing digital identity risks within the federal government. A mapping between PIV authentication mechanisms and SP 800-63 assurance levels can be found in [Section 6.3.2](#s-6-3-2).
 
 ## 6.2 PIV Card Authentication Mechanisms {#s-6-2}
 
@@ -349,7 +349,7 @@ logical information resources. For example, a cardholder may log in to their dep
 network using the PIV Card; the identity established through this authentication process can be used for
 determining access to file systems, databases, and other services available on the network.
 
-Selection of required Authenticator Assurance Level (AAL) SHALL be made using the risk management process specified in [[SP 800-63]](../_Appendix/references.md#ref-SP-800-63).
+Selection of required AAL SHALL be made using the risk management process specified in [[SP 800-63]](../_Appendix/references.md#ref-SP-800-63).
 
 [Table 6-2](#table-6-2) describes the authentication mechanisms defined for this Standard to support logical access
 control. An authentication mechanism that is suitable for a higher assurance level can also be applied to

--- a/_FIPS201/federation.md
+++ b/_FIPS201/federation.md
@@ -18,7 +18,7 @@ Note that processing the PIV credential directly is not a form of federation as 
 
 ## 7.2 Federation Assurance Level (FAL) {#s-7-2}
 
-[[SP 800-63]](../_Appendix/references.md#ref-SP-800-63) defines three dimensions of assurance: Identity Assurance Level (IAL), AAL, and FAL. The use of a PIV credential or a derived PIV credential for authentication in a federation transaction will determine the IAL and AAL of that transaction, but the FAL is determined independently of the credential itself. As with all credentials, the PIV credential can be used with any FAL, regardless of the IAL and AAL that the credential represents. Guidance for determining the correct FAL for a given application is available in [[SP 800-63]](../_Appendix/references.md#ref-SP-800-63).
+[[SP 800-63]](../_Appendix/references.md#ref-SP-800-63) defines three dimensions of assurance: IAL, AAL, and FAL. The use of a PIV credential or a derived PIV credential for authentication in a federation transaction will determine the IAL and AAL of that transaction, but the FAL is determined independently of the credential itself. As with all credentials, the PIV credential can be used with any FAL, regardless of the IAL and AAL that the credential represents. Guidance for determining the correct FAL for a given application is available in [[SP 800-63]](../_Appendix/references.md#ref-SP-800-63).
 
 The IAL, AAL, and FAL SHALL be known to the RP during the federation transaction. The IdP MAY communicate this at runtime in the assertion, for example using technologies such as Vectors of Trust [[RFC 8485]](../_Appendix/references.md#ref-RFC8485) or an Authentication Context URL [[SAML-AC]](../_Appendix/references.md#ref-SAML-AC).
 

--- a/_FIPS201/frontend.md
+++ b/_FIPS201/frontend.md
@@ -445,7 +445,7 @@ data elements are part of the data model for PIV logical credentials that suppor
 mechanisms interoperable across agencies:
 
 - a PIN;
-- a CHUID;
+- a Cardholder Unique Identifier (CHUID);
 - PIV authentication data (one asymmetric private key and corresponding certificate);
 - two fingerprint biometric templates;
 - an electronic facial image; and

--- a/_FIPS201/introduction.md
+++ b/_FIPS201/introduction.md
@@ -116,7 +116,7 @@ reason to do so (e.g., security). Deprecated features MAY continue to be used, b
 since the feature will likely be removed in the next revision of the Standard. Removed features SHALL NOT be used. For example, the CHUID
 authentication mechanism ([Section 6.2.5](authentication.md#s-6-2-5)) has been removed from this version of the Standard
 and relying systems SHALL NOT use this authentication
-mechanism.[^CHUID] The VIS authentication mechanism ([Section 6.2.6](authentication.md#s-6-2-6)) has been deprecated as a stand-alone
+mechanism.[^CHUID] The PIV Visual Credentials (VIS) authentication mechanism ([Section 6.2.6](authentication.md#s-6-2-6)) has been deprecated as a stand-alone
 authentication mechanism, but it could still be used in conjunction with other authentication mechanisms.
 
 In the case of deprecated features on PIV Cards, such as the magnetic stripe and bar codes, existing PIV Cards

--- a/_FIPS201/keymanagement.md
+++ b/_FIPS201/keymanagement.md
@@ -58,7 +58,7 @@ However, a PIV authentication or card authentication certificate MAY be revoked 
 PIV Card. The presence of a valid, unexpired, and unrevoked authentication
 certificate on a card is sufficient proof that the card was issued and is not revoked.
 
-## 5.3 X.509 CRL Contents {#s-5-3}
+## 5.3 X.509 Certificate Revocation List (CRL) Contents {#s-5-3}
 
 CAs that issue certificates corresponding to PIV private keys SHALL issue CRLs as specified in
 [[COMMON]](../_Appendix/references.md#ref-COMMON). The contents of X.509 CRLs SHALL conform to *CRL Profile* in [[PROF]](../_Appendix/references.md#ref-PROF).
@@ -67,13 +67,13 @@ CAs that issue certificates corresponding to PIV private keys SHALL issue CRLs a
 
 The content of this section has been removed as [[COMMON]](../_Appendix/references.md#ref-COMMON) reflects the requirements for department and agency CAs that might be issuing cross-certified PIV authentication certificates and card authentication certificates.
 
-## 5.5 PKI Repository and OCSP Responder(s) {#s-5-5}
+## 5.5 PKI Repository and Online Certificate Status Protocol (OCSP) Responder(s) {#s-5-5}
 
 CAs that issue certificates corresponding to PIV private keys (PIV authentication, card authentication, digital signature, or key management certificates) SHALL
 
 - maintain a Hypertext Transfer Protocol (HTTP) accessible service that publishes the CRLs for the PIV certificates it issues, as specified in [[PROF]](../_Appendix/references.md#ref-PROF);
 - maintain an HTTP accessible service that publishes any CA certificates issued to it, as specified in [[PROF]](../_Appendix/references.md#ref-PROF); and
-- operate Online Certificate Status Protocol (OCSP) services for the PIV certificates it issues, as specified in [[PROF]](../_Appendix/references.md#ref-PROF).
+- operate OCSP services for the PIV certificates it issues, as specified in [[PROF]](../_Appendix/references.md#ref-PROF).
 
 PIV authentication, card authentication, digital signature, and key management certificates SHALL
 

--- a/_FIPS201/requirements.md
+++ b/_FIPS201/requirements.md
@@ -42,7 +42,7 @@ such that
     person not entitled to the credential.
 + An issued credential is not duplicated or forged, and is not modified by an unauthorized entity.
 
-[^background]: For guidance on investigation requirements refer to [Section 2.2](../requirements/#s-2-2). NACI investigations were replaced with Tier 1 investigation upon implementation of the 2012 Federal Investigative Standards.
+[^background]: For guidance on investigation requirements refer to [Section 2.2](../requirements/#s-2-2). National Agency Check with Written Inquiries investigations were replaced with Tier 1 investigation upon implementation of the 2012 Federal Investigative Standards.
 
 [^initiation]: The initiation of a background investigation is defined as the submission of the investigative request to the Defense Counterintelligence and Security Agency, or other authorized Federal investigation service provider.
 
@@ -193,7 +193,7 @@ PIV enrollment records can be applied in several situations to include
 
 ## 2.7 PIV Identity Proofing and Registration Requirements {#s-2-7}
 
-Identity proofing and registration requirements for issuance of PIV Cards meet Identity Assurance Level 3 (IAL3) as they follow a tailored process based on [[SP 800-63A]](../_Appendix/references.md#ref-SP-800-63A) IAL3 requirements. Departments and agencies SHALL follow an identity proofing and registration process that meets the requirements defined below when issuing PIV Cards.
+Identity proofing and registration requirements for issuance of PIV Cards meet Identity Assurance Level (IAL) 3 as they follow a tailored process based on [[SP 800-63A]](../_Appendix/references.md#ref-SP-800-63A) IAL3 requirements. Departments and agencies SHALL follow an identity proofing and registration process that meets the requirements defined below when issuing PIV Cards.
 
 The organization SHALL adopt and use an identity proofing and registration process that is approved in
 accordance with [[SP 800-79]](../_Appendix/references.md#ref-SP-800-79).
@@ -558,7 +558,7 @@ required to have procedures in place to issue emergency notifications in such ca
 Issuance of a derived PIV credential is an instance of the post-enrollment binding of an authenticator described in [[SP 800-63B]](../_Appendix/references.md#ref-SP-800-63B) and SHALL be performed in accordance with the requirements that apply to physical authenticators as well as the requirements below.
 
 The issuing or binding of derived PIV credentials SHALL use valid PIV Cards in accordance with
-[[SP 800-157]](../_Appendix/references.md#ref-SP-800-157). Derived PIV credentials MAY be created at the same authentication assurance level as the PIV Card itself (AAL3), or MAY be created at a lower AAL (AAL2) depending on the security characteristics of the authenticator. The issuer SHALL attempt to promptly notify the cardholder of the binding of a derived PIV credential through an independent means that would not afford an attacker with an opportunity to erase the notification. More than one independent notification method MAY be used to ensure prompt receipt by the subscriber. Derived PIV credentials SHALL be bound to the subscriber's PIV account only by the issuer of that PIV account.
+[[SP 800-157]](../_Appendix/references.md#ref-SP-800-157). Derived PIV credentials MAY be created at the same Authenticator Assurance Level (AAL) as the PIV Card itself (AAL3), or MAY be created at a lower AAL (AAL2) depending on the security characteristics of the authenticator. The issuer SHALL attempt to promptly notify the cardholder of the binding of a derived PIV credential through an independent means that would not afford an attacker with an opportunity to erase the notification. More than one independent notification method MAY be used to ensure prompt receipt by the subscriber. Derived PIV credentials SHALL be bound to the subscriber's PIV account only by the issuer of that PIV account.
 
 ### 2.10.2 Derived PIV Credential Invalidation Requirements {#s-2-10-2}
 

--- a/_FIPS201/system.md
+++ b/_FIPS201/system.md
@@ -185,4 +185,4 @@ PIV Card Termination
     PIV Card and the data and keys needed for authentication so as to prevent any future use of the card
     for authentication.
 
-[^enroll]: In some other NIST documents such as [[SP 800-63A]](../_Appendix/references.md#ref-SP-800-63A), registration is referred to as *enrollment*.
+[^enroll]: In some other National Institute of Standards and Technology (NIST) documents such as [[SP 800-63A]](../_Appendix/references.md#ref-SP-800-63A), registration is referred to as *enrollment*.

--- a/_Frontmatter/abstract.md
+++ b/_Frontmatter/abstract.md
@@ -18,7 +18,7 @@ to federally-controlled government facilities and logical access to government i
 The Standard contains the minimum requirements for a federal personal identity verification system that
 meets the control and security objectives of Homeland Security Presidential Directive-12 [[HSPD-12]](_Appendix/references.md#ref-HSPD-12) 
 including identity proofing, registration, and issuance. The Standard also provides detailed specifications
-that will support technical interoperability among PIV systems of federal departments and agencies. It
+that will support technical interoperability among Personal Identity Verification (PIV) systems of federal departments and agencies. It
 describes the card elements, system interfaces, and security controls required to securely store, process,
 and retrieve identity credentials from the card. The physical card characteristics, storage media, and data
 elements that make up identity credentials are specified in this Standard. The interfaces and card

--- a/_Frontmatter/announcement.md
+++ b/_Frontmatter/announcement.md
@@ -90,7 +90,7 @@ Because a standard of this nature must be flexible enough to adapt to advancemen
 
 # 11. Waivers. {#f-11}
 
-The  Federal  Information  Security  Management  Act  (FISMA)  does  not  allow for waivers to FIPS that are made mandatory by the Secretary of Commerce.
+FISMA  does  not  allow for waivers to FIPS that are made mandatory by the Secretary of Commerce.
 
 # 12. Where to Obtain Copies. {#f-12}
 

--- a/_Frontmatter/foreword.md
+++ b/_Frontmatter/foreword.md
@@ -9,9 +9,9 @@ template: _pdftemplate/foreword.tex
 
 # FOREWORD
 
-The Federal Information Processing Standards Publication Series of the National Institute of Standards and Technology (NIST) is the official series of publications relating to standards and guidelines adopted and promulgated under the provisions of the Federal Information Security Management Act (FISMA) of 2002. 
+The Federal Information Processing Standards Publication Series of the National Institute of Standards and Technology is the official series of publications relating to standards and guidelines adopted and promulgated under the provisions of the Federal Information Security Management Act (FISMA) of 2002. 
 
-Comments concerning FIPS publications are welcomed and should be addressed to the Director, Information Technology Laboratory, National Institute of Standards and Technology, 100 Bureau Drive, Stop 8900, Gaithersburg, MD 20899-8900. 
+Comments concerning Federal Information Processing Standard publications are welcomed and should be addressed to the Director, Information Technology Laboratory, National Institute of Standards and Technology, 100 Bureau Drive, Stop 8900, Gaithersburg, MD 20899-8900. 
 
 ~~~
 {


### PR DESCRIPTION
- Only used once:
    - Body:
        - DHS
        - PIA
        - SAOP
        - ICAM
        - AAMVA
        - COTS
        - DPI
        - ERT
        - AIM
        - SAN
    - Frontmatter
        - GSA
        - ITL

- Questionable:
    - PKI-CAK
        - Introduction:92 _PKI-CAK_ (never expanded)
        - System:37 _PKI_ (expanded)
    - _NIST_ only ever used in body footnotes. What are expansion rules?
    - _FIPS PUBS_ vs _FIPS PUB_s (frontmatter)
    - _FIPS PUBS_ vs _FIPS_ (frontmatter)

Reset for Frontmattter, Body, and Appendix

If the acronym first appeared in a section header, acronym was expanded twice. My preference would be to not expand at all in the title.

Will close usnistgov/piv-issues#180.