### PR TITLE
Italics for glossary terms in glossary definitions

### DIFF
--- a/_Appendix/glossary.md
+++ b/_Appendix/glossary.md
@@ -455,7 +455,7 @@ GUID
 : Global Unique Identification Number
 
 h
-: Hours
+: hours
 
 HSPD
 : Homeland Security Presidential Directive


### PR DESCRIPTION
Use italics when a glossary word appears in a _different_ glossary definition.

Personal note: after seeing it, I'm not sure I like it, and it may detract from readability. There's some inconsistency in terminology, so italics are sometimes in the middle of a phrase or there are two terms back-to-back (e.g., `PIV Card` `issuers`, `cardholder` `identity`, etc.). It is still useful to know what is a term and what isn't. I'm torn on if I would want this merged, or would rather revert all italics.

Toward usnistgov/piv-issues#181.