### PR TITLE
Biometrics across multiple sessions

### DIFF
--- a/_FIPS201/requirements.md
+++ b/_FIPS201/requirements.md
@@ -132,7 +132,7 @@ authentication processes from [Section 6.2](authentication.md#s-6-2).
 The electronic facial image is a secondary means of authentication during operator-attended PIV issuance and maintenance processes
 when fingerprint biometric data records are unavailable.
 
-PIV background investigation, identity proofing, registration, and issuance processes MAY be performed across multiple sessions at different facilities. If multiple sessions are needed, the applicant SHALL be linked through a positive biometric verification decision by comparing biometric characteristics captured at the previous session with biometric characteristics captured during the current session. Issuers SHALL follow applicable federal law and regulations regrding the retention and destruction of biometric data.
+PIV background investigation, identity proofing, registration, and issuance processes MAY be performed across multiple sessions at different facilities. If multiple sessions are needed, the applicant SHALL be linked through a positive biometric verification decision by comparing biometric characteristics captured at a previous session with biometric characteristics captured during the current session. Issuers SHALL follow applicable federal law and regulations regrding the retention and destruction of biometric data.
 
 ## 2.6 PIV Enrollment Records {#s-2-6}
 


### PR DESCRIPTION
We've previously (and frequently) discussed biometric collection and verification that is spread across multiple visits/sessions:

- fingerprint for background investigation
- biometric enrollment for PIV card personalization
- identity proofing and registration
- issuance

In particular, we hypothesized a scenario where proofing might be done across multiple processes, but ultimately decided that was unlikely.  Still, the four bullets above could easily be three different trips.

Starting from #74 from @gfiumara, I tried to come up with some broader text.  However, I'm not convinced this really says anything that isn't already implicitly or explicitly said elsewhere and inclined to say this issue and PR should be closed without merging. But maybe others will see more value in this.

I'll note there are edge cases regarding biometrics that we never really consider.  Section 2.4 for PIV card biometric enrollment says that it needs to be compared against the fingerprints taken in 2.3 (the background investigation).  Not only is this almost never done, but it's particularly complicated in the case where you're not doing a new investigation.  I don't know how to fix this, or even if we want to fix this.

This was originally intended to close usnistgov/PIV-issues/issues/178