### PR TITLE
trimming down A.1 - PCI/DPCI accreditation

### DIFF
--- a/_Appendix/accreditation.md
+++ b/_Appendix/accreditation.md
@@ -13,8 +13,7 @@ _This appendix is normative._ It provides compliance requirements for PIV valida
 {:latex-toc="A.1 Accreditation of PIV Card Issuers and Derived PIV Credential Issuers"}
 
 [[HSPD-12]](references.md#ref-HSPD-12) requires that PIV credentials be issued by providers whose reliability has been established by an
-official accreditation process. The accreditation of the credential issuer SHALL be reviewed through a third-party assessment to enhance the trustworthiness of the credential. To facilitate consistent independent
-validation, NIST published PIV Card Issuer (PCI) and Derived PIV Credential Issuer (DPCI) guidelines in [[SP 800-79]](references.md#ref-SP-800-79). 
+official accreditation process. Consistent assessment guidelines are established for PIV Card Issuers (PCI) and Derived PIV Credential Issuers (DPCI) in [[SP 800-79]](references.md#ref-SP-800-79), which SHALL be followed by all credential issuers in order to achieve accreditation.
 
 The entire spectrum of activities in the PCI and DPCI accreditation methodology is divided into the following four
 phases:


### PR DESCRIPTION
This pull request addresses [209](https://github.com/usnistgov/PIV-issues/issues/209).  It is an attempt to trim down A.1 by removing some of the revision history of -79 and also removing some of the in-depth  details but  leaving higher level descriptor about phases of accreditation.