### PR TITLE
Certificate Path Validation points to RFC 5280

### DIFF
--- a/_FIPS201/authentication.md
+++ b/_FIPS201/authentication.md
@@ -136,7 +136,7 @@ The following steps SHALL be performed for PKI-AUTH:
 
 - The PIV authentication certificate is read from the PIV Card Application.
 - The relying system validates the PIV authentication certificate from the PIV Card Application using
-    standards-compliant PKI path validation[^pivpath] to ensure that it is neither expired nor revoked and that it is
+   certificate path validation[^pivpath] algorithms specified in [[RFC 5280]](references.md#ref-RFC5280) to ensure that it is neither expired nor revoked and that it is
     from a trusted source.
 - The cardholder is prompted to enter a PIN, which is used to activate the card. If implemented,
     other card activation mechanisms, as specified in [[SP 800-73]](../_Appendix/references.md#ref-SP-800-73), MAY be used to activate the card.
@@ -165,7 +165,7 @@ The following steps SHALL be performed for PKI-CAK:
 
 - The card authentication certificate is read from the PIV Card Application.
 - The relying system validates the card authentication certificate from the PIV Card Application using
-    standards-compliant PKI path validation[^cacpath] to ensure that it is neither expired nor revoked and that it is
+    certificate path validation[^cacpath] algorithms specified in [[RFC 5280]](references.md#ref-RFC5280) to ensure that it is neither expired nor revoked and that it is
     from a trusted source.
 - The relying system issues a challenge string to the card and requests an asymmetric operation in
     response.


### PR DESCRIPTION
Change "standards-compliant PKI path validation" to certificate path validation algorithms specified in RFC 5280.  Note this is written as a description of what is done, rather than requirements for what must be done.

Please check that I did references correctly.  We already had RFC 5280 in the reference list, so this is mostly adding the in-line reference.

Closes usnistgov/piv-issues/issues/207