### PR TITLE
edit #3

### DIFF
--- a/_FIPS201/requirements.md
+++ b/_FIPS201/requirements.md
@@ -560,23 +560,23 @@ following circumstances:
 + a cardholder is determined to hold a fraudulent identity.
 
 Similar to the situation in which the PIV Card is compromised, normal termination procedures
-must be in place:
+must be in place. The PIV Card SHALL be revoked through the following procedure:
 
-+ The PIV Card SHALL be revoked through the following procedure:
-    * The PIV Card SHALL be collected and destroyed, if possible.
-    * Per OPM guidance, the Central Verification System (or successor) SHALL be updated to reflect the change in status.
-    * Any databases maintained by the PIV Card issuer that indicate current valid or invalid
-        FASC-N or card UUID values SHALL be updated to reflect the change in status.
-    * If the PIV Card cannot be collected and destroyed, the CA SHALL be informed and the
-        certificates corresponding to the PIV authentication key and the asymmetric card
-        authentication key on the PIV Card SHALL be revoked. The certificates corresponding to the
-        digital signature and key management keys SHALL also be revoked, if present.
-+ The PII collected from the cardholder is disposed of in accordance with the stated privacy and data
-    retention policies of the department or agency.
+* The PIV Card SHALL be collected and destroyed, if possible.
+* Per OPM guidance, the Central Verification System (or successor) SHALL be updated to reflect the change in status.
+* Any databases maintained by the PIV Card issuer that indicate current valid or invalid
+    FASC-N or card UUID values SHALL be updated to reflect the change in status.
+* If the PIV Card cannot be collected and destroyed, the CA SHALL be informed and the
+    certificates corresponding to the PIV authentication key and the asymmetric card
+    authentication key on the PIV Card SHALL be revoked. The certificates corresponding to the
+    digital signature and key management keys SHALL also be revoked, if present.
 
 If the card cannot be collected, normal termination procedures SHALL be completed within 18&nbsp;hours of
 notification. In certain cases, 18&nbsp;hours is an unacceptable delay and in those cases emergency procedures
 SHOULD be executed to disseminate the information as rapidly as possible.
+
+The PII collected from the cardholder SHALL be disposed of in accordance with the stated privacy and data
+retention policies of the department or agency.
 
 ## 2.10 Derived PIV Credentials {#s-2-10}
 


### PR DESCRIPTION
**790: Why is there  a "at least? Is it necessary (intended)  to to have more than one 'entire id proofing session'?** (no edits done - discuss)
956: card UUID instead of UUID
1019:  Something wrong.  Text for "general computing platform PIN reset" is cut off.  Need new subsection to cover that case.  ..Start with:  "Remote PIN reset on a general computing platform (e.g., desktop, laptop) shall only be performed if the following requirements are met:

1045:  and overall:  text in bullets seemed to be 'smaller font (overall in -2).
1050:  See -> see
1053 - 1055 two "as follows" right after the other (or very closely) - reads weird.  Tried to rephrase.
1060: UUID -> Card UUID
**1084:  The sentence is not clear.  "shall use the PIV card" for what?** Note: Did not edit - want team feedback.
**587, 591, and 625, 640, 672 all talk about linking bio from prior visit.  Do we really need all 3 -- can we delete at least 587?** (no edits done - want to discuss first)