### PR TITLE
PIV System (3) edit 4

### DIFF
--- a/_FIPS201/system.md
+++ b/_FIPS201/system.md
@@ -53,7 +53,7 @@ information about data flow and connections between components.
 
 ### 3.1.1 PIV Front-End Subsystem {#s-3-1-1}
 
-The PIV Front-End Subsystem in [Figure 3-1](#fig-3-1) consists of credentials and devices that interact during authentication.
+The PIV Front-End Subsystem in [Figure 3-1](#fig-3-1) consists of credentials and devices that are used during authentication.
 The PIV Card will be issued to the applicant when all identity proofing, registration, and issuance
 processes have been completed. Derived PIV credentials might also be registered after these processes are complete. The PIV Card takes the physical form of the [[ISO 7816]](../_Appendix/references.md#ref-ISO7816) ID-1 card type (i.e., traditional payment card), with one or more
 embedded Integrated Circuit Chips (ICC) that provide memory capacity and computational capability. The


### PR DESCRIPTION
1202:  "front end conisist of credentials used to interact with credential"?  Rephrase to " consists of credentials and devices that interact during authentication. "
1209:  holder -> cardholder
1221:  personal -> cardholder
1287: and uses -> using
1295:  end-of-life 'activity"
1282:  delete 'identification and' -> just use authentication (remnant of I&A component - which we deleted).  
1320:  derived PIV credential -> a derived PIV credential - since the sentence then talks about  'the credential'

**1335: take out word "many" as we say in line 1093-94: "Derived PIV credentials 1092 SHALL be bound to the cardholder’s PIV account only by the organization that manages that PIV account"** (not changes made - discuss).