### PR TITLE
Section 4 part 1 edits

### DIFF
--- a/_FIPS201/frontend.md
+++ b/_FIPS201/frontend.md
@@ -271,7 +271,7 @@ Zone 3F: Signature
 Zone 4F: Agency-Specific Text Area
 : If used, this area can be used for printing agency-specific
     requirements, such as employee status, as shown in [Figure 4-2](#fig-4-2).
-    Note that this zone overlaps with an area that some card manufacturers do not allow to be used for printing.
+    Note that this zone overlaps with an area that some card manufacturers might not allow to be used for printing.
 
 Zone 5F: Rank
 : If used, the cardholder's rank SHALL be printed in the area as illustrated in [Figure 4-2](#fig-4-2).
@@ -280,7 +280,7 @@ Zone 5F: Rank
 Zone 6F: Portable Data File (PDF) Two-Dimensional Bar Code (Deprecated)
 : This bar code is deprecated in this version of the Standard. In a future version of this Standard, the bar code may be removed. If used, the PDF bar code SHALL be placed in the general area depicted in [Figure 4-2](#fig-4-2) (i.e., left side of the card). If Zone 3F (a cardholder signature) is used, the size of the PDF bar code may be affected. The card issuer SHALL confirm that a PDF used in
     conjunction with a PIV Card containing a cardholder signature will satisfy the anticipated PDF data storage requirements. 
-    Note that this zone overlaps with an area that some card manufacturers may not allow to be used for printing.
+    Note that this zone overlaps with an area that some card manufacturers might not allow to be used for printing.
 
 Zone 9F: Header
 : If used, the text "United States Government" SHALL be placed as depicted in 
@@ -305,7 +305,7 @@ Zone 12F: Footer
     abbreviation (alpha-3 format) in accordance with [[ISO 3166]](../_Appendix/references.md#ref-ISO3166). [Figure 4-4](#fig-4-4)
     illustrates an example of using country abbreviations for a card issued to a foreign national.
     
-    Note that this zone overlaps with an area that some card manufacturers may not allow to be used for printing.
+    Note that this zone overlaps with an area that some card manufacturers might not allow to be used for printing.
 
 Zone 13F: Issue Date
 : If used, the card issuance date SHALL be printed above the Zone 14F expiration


### PR DESCRIPTION
bold items, I did not edit. 
1366:  includes -> include
**1482:  lower case primary and secondary and identifiers in this section (lines 1485, 1489, 1491**
1488: paragraph space missing (I did a line space, but not sure if that took care of it). 
**1513: table is in middle of 15F text.  It should be right after 2F
1517: need spacing between listed items for employee color scheme (both top and bottom)**
1556: Incomplete sentence.  placement of what?   add:  of the ICC(s) and related components"
1563: do not allow -> MAY not allow
1569: may -> MAY
1571: may -> MAY
1574:  do not allow -> MAY not allow
1598: do not allow -> MAY not allow

1623: should-> SHOULD
1629: should -> SHOULD
1635:  may-> MAY
1656: may -> MAY
1690: since this subsection talks about authentication and lists the credentials, a footnote is appropriate.  add a footnote: The CHUID as an authentication mechanims (Section 6.2.5) has been
removed from this version of the Standard. The CHUID data element itself, however, has not been removed and continues to be mandatory as it supports other PIV authentication mechanisms.
1724:  This is the biggest section about the CHUID - yet, it does not state that the authentication mechanism is deprecated.  Suggest to add the following text.

The CHUID authentication mechanims (Section 6.2.5) has been removed from this version of the Standard. The CHUID data element, however, has not been removed and continues to be mandatory as it supports other PIV authentication mechanisms. For example, the BIO, BIO-A, and SYM-CAK authentication mechanisms use the CHUID data  element as a source for the card’s expiration date. The CHUID data element also provides the content signing certificate for some authentication mechanisms and unique identifiers for PACS ACLs. 
1800:  This para is missplaced. I moved it back (underneath para beginning with 1784