### PR TITLE
part 4 2nd set of edits

### DIFF
--- a/_FIPS201/frontend.md
+++ b/_FIPS201/frontend.md
@@ -793,7 +793,7 @@ Cardholder activation is described in [Section 4.3.1](frontend.md#s-4-3-1) and c
 [Section 4.3.2](frontend.md#s-4-3-2).
 
 [^activation]: Activation in this context refers to the unlocking of the PIV Card Application so privileged operations can be performed.
-[^privileged]: Use of the card authentication key is not considered a privileged operation.
+[^privileged]: A read of a CHUID or use of the card authentication key is not considered a privileged operation.
 
 ### 4.3.1 Activation by Cardholder {#s-4-3-1}
 


### PR DESCRIPTION
1908:  The "as follows" seems out of place  Maybe just take out "as follows". Or maybe the following sentence needs to be bullet-ized?	
**1928: - 1939:  We made bullets for off-card matched bio, but not for OCC.  Shall both be treated the same. Make OCC bullet-ized as well?**
1963: - footnote 25 - delete "of the CHUID or" as it implies use of CHUID as an authentication mechanism, when we removed it.
2018: - switch "OCC data or PIN data" as PIN is more predominately used. Also use "activated" instead of 'used"
2019: - same again as comment in 2018 (switch)
2022: - same again as comment in 2018 (switch)