### PR TITLE
minor edits on 6

### DIFF
--- a/_FIPS201/authentication.md
+++ b/_FIPS201/authentication.md
@@ -51,7 +51,7 @@ The content of this section has been removed as OMB [[M-04-04]](../_Appendix/ref
 
 The following subsections define the basic types of authentication mechanisms that are supported by the
 credential set hosted by the PIV Card Application. PIV Cards can be used for authentication in
-environments that are equipped with card readers. Card readers can be contact readers or contactless readers. The usage environment affects the PIV
+environments that are equipped with contact or contactless card readers. The usage environment affects the PIV
 authentication mechanisms that may be applied to a particular situation.
 
 ### 6.2.1 Authentication Using Off-Card Biometric One-to-One Comparison {#s-6-2-1}


### PR DESCRIPTION
- **why is  id-fpki-common-High policy out?  
2068: - why is common-high out?** 
2163: - Remove 'when present' (left over edits from last time, when we removed that cards can be used for non-automated means).
2167: - pre-pend "These' in front of sentence.  replace "these in next sentence.
2216: - "as with BIO" -> "as with BIO and BIO-A"
2258: - delete algorithms as it has different meaning in general in this document (i.e., cyrpto)
2232: - delete algorithms
2370: - delete 'basic'
2370: - delete 'as'
2374: - cardholder's 
**2382: - add SP 800-53** 
**2445: - append "or it might be pre-established.**