### PR TITLE
Termination- DPCs

### DIFF
--- a/_FIPS201/requirements.md
+++ b/_FIPS201/requirements.md
@@ -574,7 +574,7 @@ must be in place. The PIV Card SHALL be revoked through the following procedure:
     authentication key on the PIV Card SHALL be revoked. The certificates corresponding to the
     digital signature and key management keys SHALL also be revoked, if present.
     
-In addition, the PIV Card termination procedures SHALL ensure all derived PIV credentials bound to the cardholder are invalidated as specified in [Section 2.10.2](requirements.md#s-2-10-2).
+In addition, the PIV Card termination procedures SHALL ensure all derived PIV credentials bound to the PIV account are invalidated as specified in [Section 2.10.2](requirements.md#s-2-10-2).
 
 If the card cannot be collected, normal termination procedures SHALL be completed within 18&nbsp;hours of
 notification. In certain cases, 18&nbsp;hours is an unacceptable delay and in those cases emergency procedures


### PR DESCRIPTION
Adds specific language requiring invalidation of DPCs as part of PIV card termination process.  This effectively restates requirements already in Section 2.10.2.

Because the requirements are already there in the DPC section, this would be safe to ignore if we so desired.

Closes usnistgov/PIV-issues#229