### PR TITLE
Don't activate PIV Card before biometric comparison

### DIFF
--- a/_FIPS201/requirements.md
+++ b/_FIPS201/requirements.md
@@ -331,11 +331,11 @@ of the federal department or agency.
 + Biometric data used to personalize the PIV Card **SHALL** be those captured during the identity proofing and registration process.
 + During the issuance process, the issuer **SHALL** verify that the individual to whom the PIV Card is to be
     issued is the same as the intended applicant/recipient as approved by the appropriate authority.
-    Before the PIV Card is provided to the applicant, the issuer **SHALL** perform a one-to-one comparison of the
-    applicant against biometric data records available on the PIV Card or in the PIV enrollment record. The one-to-one
+    Before the PIV Card is activated and provided to the applicant, the issuer **SHALL** perform a one-to-one comparison of the
+    applicant against biometric data records in the PIV enrollment record or unsigned biometric data records that would be transferred to and signed on the PIV Card. The one-to-one
     comparison requires either a comparison of fingerprints or, if unavailable, other optional biometric data records that are
     available. Minimum accuracy requirements for the biometric verification are specified in [[SP 800-76]](../_Appendix/references.md#ref-SP-800-76). On
-    a positive biometric verification decision, the PIV Card **SHALL** be released to the applicant. If the biometric verification decision is negative, or if
+    a positive biometric verification decision, the biometric data records **SHALL** be signed and the PIV Card **SHALL** be activated and released to the applicant. If the biometric verification decision is negative, or if
     no biometric data records are available, the cardholder **SHALL** provide two identity source documents (as
     specified in [Section 2.7](requirements.md#s-2-7)), and an attending operator **SHALL** inspect these and compare the cardholder
     with the photograph printed on the PIV Card.

--- a/_FIPS201/requirements.md
+++ b/_FIPS201/requirements.md
@@ -335,7 +335,7 @@ of the federal department or agency.
     applicant against biometric data records in the PIV enrollment record. The one-to-one
     comparison requires either a comparison of fingerprints or, if unavailable, other optional biometric data records that are
     available. Minimum accuracy requirements for the biometric verification are specified in [[SP 800-76]](../_Appendix/references.md#ref-SP-800-76). On
-    a positive biometric verification decision the PIV Card **SHALL** be activated and released to the applicant. If the biometric verification decision is negative, or if
+    a positive biometric verification decision, the PIV Card **SHALL** be activated and released to the applicant. If the biometric verification decision is negative, or if
     no biometric data records are available, the cardholder **SHALL** provide two identity source documents (as
     specified in [Section 2.7](requirements.md#s-2-7)), and an attending operator **SHALL** inspect these and compare the cardholder
     with the photograph printed on the PIV Card.

--- a/_FIPS201/requirements.md
+++ b/_FIPS201/requirements.md
@@ -332,7 +332,7 @@ of the federal department or agency.
 + Biometric data used to personalize the PIV Card **SHALL** be those captured during the identity proofing and registration process.
 + During the issuance process, the issuer **SHALL** verify that the individual to whom the PIV Card is to be
     issued is the same as the intended applicant/recipient as approved by the appropriate authority.
-    Before the PIV Card is activated and provided to the applicant, the issuer **SHALL** perform a one-to-one comparison of the
+    After the PIV Card is personalized, but before the PIV Card is activated and provided to the applicant, the issuer **SHALL** perform a one-to-one comparison of the
     applicant against biometric data records available in the PIV enrollment record.
     Minimum accuracy requirements for biometric verification and presentation attack detection are specified in [[SP 800-76]](../_Appendix/references.md#ref-SP-800-76). On
     a positive biometric verification decision, the PIV Card **SHALL** be activated and released to the applicant. If the biometric verification decision is negative, or if

--- a/_FIPS201/requirements.md
+++ b/_FIPS201/requirements.md
@@ -333,7 +333,7 @@ of the federal department or agency.
 + During the issuance process, the issuer **SHALL** verify that the individual to whom the PIV Card is to be
     issued is the same as the intended applicant/recipient as approved by the appropriate authority.
     Before the PIV Card is activated and provided to the applicant, the issuer **SHALL** perform a one-to-one comparison of the
-    applicant against biometric data records available on the PIV Card or in the PIV enrollment record.
+    applicant against biometric data records available in the PIV enrollment record.
     Minimum accuracy requirements for biometric verification and presentation attack detection are specified in [[SP 800-76]](../_Appendix/references.md#ref-SP-800-76). On
     a positive biometric verification decision, the PIV Card **SHALL** be activated and released to the applicant. If the biometric verification decision is negative, or if
     no biometric data records are available, the cardholder **SHALL** provide two identity source documents (as

--- a/_FIPS201/requirements.md
+++ b/_FIPS201/requirements.md
@@ -332,10 +332,10 @@ of the federal department or agency.
 + During the issuance process, the issuer **SHALL** verify that the individual to whom the PIV Card is to be
     issued is the same as the intended applicant/recipient as approved by the appropriate authority.
     Before the PIV Card is activated and provided to the applicant, the issuer **SHALL** perform a one-to-one comparison of the
-    applicant against biometric data records in the PIV enrollment record or unsigned biometric data records that would be transferred to and signed on the PIV Card. The one-to-one
+    applicant against biometric data records in the PIV enrollment record. The one-to-one
     comparison requires either a comparison of fingerprints or, if unavailable, other optional biometric data records that are
     available. Minimum accuracy requirements for the biometric verification are specified in [[SP 800-76]](../_Appendix/references.md#ref-SP-800-76). On
-    a positive biometric verification decision, the biometric data records **SHALL** be signed and the PIV Card **SHALL** be activated and released to the applicant. If the biometric verification decision is negative, or if
+    a positive biometric verification decision the PIV Card **SHALL** be activated and released to the applicant. If the biometric verification decision is negative, or if
     no biometric data records are available, the cardholder **SHALL** provide two identity source documents (as
     specified in [Section 2.7](requirements.md#s-2-7)), and an attending operator **SHALL** inspect these and compare the cardholder
     with the photograph printed on the PIV Card.


### PR DESCRIPTION
Would close #389, but requires discussion. Is this possible?

I assume that during the activation process, the facial image, iris images, and fingerprint templates are sitting as files somewhere, unsigned. This PR assumes that we can perform a comparison against them, and if positive, sign them and write them to the card. This also assumes that "activated" means signing things on the card.