### PR TITLE
OCC Retries + Reset

### DIFF
--- a/_FIPS201/requirements.md
+++ b/_FIPS201/requirements.md
@@ -495,7 +495,7 @@ can be reset in certain circumstances.
 
 The PIN on a PIV Card may need to be reset if the cardholder has
 forgotten the PIN or if PIN-based cardholder authentication has been disabled by the usage of an
-invalid PIN more than the allowed number of retries. A maximum of 10 consecutive activation retries (i.e., PIN or OCC attempts) **SHALL** be permitted unless a lower limit is stipulated by the department or agency.
+invalid PIN more than the allowed number of retries. OCC may need to be reset if the cardholder has developed epidermal scaring or similar, resulting in false negative biometric verification decisions, or if OCC has been disabled by exceeding the allowed number of negative biometric verification decisions.  A maximum of 10 consecutive activation retries (i.e., PIN or OCC attempts) **SHALL** be permitted unless a lower limit is stipulated by the department or agency.
 Cardholders **MAY** change their PINs at any time by providing the current PIN and the new PIN values.
 PIN reset **MAY** be performed in person at an issuing facility, at a kiosk operated by the issuer, or
 remotely via a general computing platform or a supervised remote identity proofing station:

--- a/_FIPS201/requirements.md
+++ b/_FIPS201/requirements.md
@@ -498,7 +498,7 @@ can be reset in certain circumstances.
 
 The PIN on a PIV Card may need to be reset if the cardholder has
 forgotten the PIN or if PIN-based cardholder authentication has been disabled by the usage of an
-invalid PIN more than the allowed number of retries. OCC may need to be reset if the cardholder has developed epidermal scaring or similar, resulting in false negative biometric verification decisions, or if OCC has been disabled by exceeding the allowed number of negative biometric verification decisions.  A maximum of 10 consecutive activation retries for each of the activation methods (i.e., PIN and OCC attempts) **SHALL** be permitted unless a lower limit is stipulated by the department or agency.
+invalid PIN more than the allowed number of retries. OCC may need to be reset if the cardholder has developed epidermal scarring or similar, resulting in false negative biometric verification decisions, or if OCC has been disabled by exceeding the allowed number of negative biometric verification decisions.  A maximum of 10 consecutive activation retries for each of the activation methods (i.e., PIN and OCC attempts) **SHALL** be permitted unless a lower limit is stipulated by the department or agency.
 
 Cardholders **MAY** change their PINs at any time by providing the current PIN and the new PIN values, as specified in [[SP 800-73]](../_Appendix/references.md#ref-SP-800-73).
 
@@ -553,7 +553,7 @@ Regardless of the PIN reset procedure used, the chosen PIN **SHALL** meet the ac
 
 The PIV Card's activation methods for OCC may also be 
 reset by the card issuer. Before the reset, the issuer 
-**SHALL** perform a biometric verification of the cardholder to the biometric data records in the PIV enrollment record[^occ_reset_characteristic]. If the biometric verification decision is negative or no alternative biometric data records are available, the 
+**SHALL** perform a biometric verification of the cardholder to the biometric data records in the PIV enrollment record.[^occ_reset_characteristic] If the biometric verification decision is negative or no alternative biometric data records are available, the 
 cardholder **SHALL** provide the PIV Card to be reset and another primary identity source document (as
 specified in [Section 2.7](requirements.md#s-2-7)). An attending operator **SHALL** inspect these and compare the cardholder with the
 electronic facial image retrieved from the enrollment data record and the photograph printed on the PIV Card.

--- a/_FIPS201/requirements.md
+++ b/_FIPS201/requirements.md
@@ -495,7 +495,7 @@ can be reset in certain circumstances.
 
 The PIN on a PIV Card may need to be reset if the cardholder has
 forgotten the PIN or if PIN-based cardholder authentication has been disabled by the usage of an
-invalid PIN more than the allowed number of retries. OCC may need to be reset if the cardholder has developed epidermal scaring or similar, resulting in false negative biometric verification decisions, or if OCC has been disabled by exceeding the allowed number of negative biometric verification decisions.  A maximum of 10 consecutive activation retries (i.e., PIN or OCC attempts) **SHALL** be permitted unless a lower limit is stipulated by the department or agency.
+invalid PIN more than the allowed number of retries. OCC may need to be reset if the cardholder has developed epidermal scaring or similar, resulting in false negative biometric verification decisions, or if OCC has been disabled by exceeding the allowed number of negative biometric verification decisions.  A maximum of 10 consecutive activation retries for each of the activation methods (i.e., PIN and OCC attempts) **SHALL** be permitted unless a lower limit is stipulated by the department or agency.
 Cardholders **MAY** change their PINs at any time by providing the current PIN and the new PIN values.
 PIN reset **MAY** be performed in person at an issuing facility, at a kiosk operated by the issuer, or
 remotely via a general computing platform or a supervised remote identity proofing station:

--- a/_FIPS201/requirements.md
+++ b/_FIPS201/requirements.md
@@ -548,7 +548,7 @@ Regardless of the PIN reset procedure used, the chosen PIN **SHALL** meet the ac
 
 The PIV Card's activation methods for OCC may also be 
 reset by the card issuer. Before the reset, the issuer 
-**SHALL** perform a biometric verification of the cardholder to the biometric data records in the PIV enrollment record. If no alternative biometric data records are available, the 
+**SHALL** perform a biometric verification of the cardholder to the biometric data records in the PIV enrollment record[^occ_reset_characteristic]. If no alternative biometric data records are available, the 
 cardholder **SHALL** provide the PIV Card to be reset and another primary identity source document (as
 specified in [Section 2.7](requirements.md#s-2-7)). An attending operator **SHALL** inspect these and compare the cardholder with the
 electronic facial image retrieved from the enrollment data record and the photograph printed on the PIV Card.
@@ -556,6 +556,8 @@ electronic facial image retrieved from the enrollment data record and the photog
 Departments and agencies **MAY** adopt more stringent procedures for PIN/OCC reset (including
 disallowing resets); such procedures **SHALL** be formally documented by each department
 and agency.
+
+[^occ_reset_characteristic]: If OCC is being reset due to epidermal damage on a specific finger, it may be prudent to perform the biometric comparison with a different finger or different biometric characteristic. However, it is possible that the comparison algorithm available to the issuer could obtain a positive biometric verification decision with damaged epidermis while the OCC algorithm could not.
 
 ### 2.9.4 PIV Card Termination Requirements {#s-2-9-4}
 

--- a/_FIPS201/requirements.md
+++ b/_FIPS201/requirements.md
@@ -495,7 +495,7 @@ can be reset in certain circumstances.
 
 The PIN on a PIV Card may need to be reset if the cardholder has
 forgotten the PIN or if PIN-based cardholder authentication has been disabled by the usage of an
-invalid PIN more than the allowed number of retries. A maximum of 10 consecutive PIN retries **SHALL** be permitted unless a lower limit is stipulated by the department or agency.
+invalid PIN more than the allowed number of retries. A maximum of 10 consecutive activation retries (i.e., PIN or OCC attempts) **SHALL** be permitted unless a lower limit is stipulated by the department or agency.
 Cardholders **MAY** change their PINs at any time by providing the current PIN and the new PIN values.
 PIN reset **MAY** be performed in person at an issuing facility, at a kiosk operated by the issuer, or
 remotely via a general computing platform or a supervised remote identity proofing station:

--- a/_FIPS201/requirements.md
+++ b/_FIPS201/requirements.md
@@ -552,6 +552,7 @@ reset by the card issuer. Before the reset, the issuer
 cardholder **SHALL** provide the PIV Card to be reset and another primary identity source document (as
 specified in [Section 2.7](requirements.md#s-2-7)). An attending operator **SHALL** inspect these and compare the cardholder with the
 electronic facial image retrieved from the enrollment data record and the photograph printed on the PIV Card.
+When replacing one fingerprint used for OCC, all other OCC data **SHALL** also be replaced.
 
 Departments and agencies **MAY** adopt more stringent procedures for PIN/OCC reset (including
 disallowing resets); such procedures **SHALL** be formally documented by each department

--- a/_FIPS201/requirements.md
+++ b/_FIPS201/requirements.md
@@ -548,7 +548,7 @@ Regardless of the PIN reset procedure used, the chosen PIN **SHALL** meet the ac
 
 The PIV Card's activation methods for OCC may also be 
 reset by the card issuer. Before the reset, the issuer 
-**SHALL** perform a biometric verification of the cardholder to the biometric data records in the PIV enrollment record[^occ_reset_characteristic]. If no alternative biometric data records are available, the 
+**SHALL** perform a biometric verification of the cardholder to the biometric data records in the PIV enrollment record[^occ_reset_characteristic]. If the biometric verification decision is negative or no alternative biometric data records are available, the 
 cardholder **SHALL** provide the PIV Card to be reset and another primary identity source document (as
 specified in [Section 2.7](requirements.md#s-2-7)). An attending operator **SHALL** inspect these and compare the cardholder with the
 electronic facial image retrieved from the enrollment data record and the photograph printed on the PIV Card.


### PR DESCRIPTION
Closes #615.

However, do we want to separate 2.9.3 into subsections (2.9.3.1 and 2.9.3.2) to differentiate between the PIN and OCC reset opportunities? Currently, this only allows for OCC to be reset in person. Certainly OCC could also be reset at a SRIP kiosk? OCC could **not** be reset on a general computing platform. Debatable if it could be reset at an issuer-operated kiosk.