### PR TITLE
Split Max Retry PIN Limit Sentence

### DIFF
--- a/_FIPS201/requirements.md
+++ b/_FIPS201/requirements.md
@@ -495,7 +495,7 @@ can be reset in certain circumstances.
 
 The PIN on a PIV Card may need to be reset if the cardholder has
 forgotten the PIN or if PIN-based cardholder authentication has been disabled by the usage of an
-invalid PIN more than the allowed number of retries. A maximum of 10 consecutive PIN retries **SHALL** be permitted unless a lower limit is stipulated by the department or agency.
+invalid PIN more than the allowed number of retries. No more than of 10 consecutive PIN retries **SHALL** be permitted. Card issuers **MAY** further restrict the maximum retry limit to a lower value. 
 Cardholders **MAY** change their PINs at any time by providing the current PIN and the new PIN values.
 PIN reset **MAY** be performed in person at an issuing facility, at a kiosk operated by the issuer, or
 remotely via a general computing platform or a supervised remote identity proofing station:

--- a/_FIPS201/requirements.md
+++ b/_FIPS201/requirements.md
@@ -495,7 +495,7 @@ can be reset in certain circumstances.
 
 The PIN on a PIV Card may need to be reset if the cardholder has
 forgotten the PIN or if PIN-based cardholder authentication has been disabled by the usage of an
-invalid PIN more than the allowed number of retries. No more than of 10 consecutive PIN retries **SHALL** be permitted. Card issuers **MAY** further restrict the maximum retry limit to a lower value. 
+invalid PIN more than the allowed number of retries. No more than 10 consecutive PIN retries **SHALL** be permitted. Card issuers **MAY** further restrict the maximum retry limit to a lower value. 
 Cardholders **MAY** change their PINs at any time by providing the current PIN and the new PIN values.
 PIN reset **MAY** be performed in person at an issuing facility, at a kiosk operated by the issuer, or
 remotely via a general computing platform or a supervised remote identity proofing station:


### PR DESCRIPTION
Closes #373 

No more than 10.  Card issuers may set a lower limit.

Note: Is card issuer the right term there?  Or departments and agencies?  